### PR TITLE
Add option to delete past entries

### DIFF
--- a/src/api/analytics.js
+++ b/src/api/analytics.js
@@ -25,6 +25,18 @@ export const reasonTap = async (reason) => {
   }
 };
 
+// Modified to track deletions
+export const entryDelete = async (reason, date) => {
+  try {
+    await analytics().logEvent('entry_delete', {
+      reason,
+      date,
+    });
+  } catch (e) {
+    console.log('Unable to log analytics event:', e);
+  }
+};
+
 // Funnel events
 export const openSourceOrWhyNeededTap = async () => {
   try {

--- a/src/api/constants.js
+++ b/src/api/constants.js
@@ -11,6 +11,7 @@ export const colors = {
   dark: '#2d3436',
   light: '#ffffff',
   reddit: '#FF4500',
+  background: '#f2f2f2',
 };
 
 export const reasons = [

--- a/src/redux/actions/answer.js
+++ b/src/redux/actions/answer.js
@@ -42,10 +42,10 @@ export const fetchAnswers = () => (dispatch) => {
       .orderBy('createdAt', 'desc')
       .onSnapshot(
         (snapshot) => {
-          const answers = snapshot.docs.map((doc) => {
-            const answer = doc.data();
-            return answer;
-          });
+          const answers = snapshot.docs.map((doc) => ({
+            ...doc.data(),
+            id: doc.id
+          }));
           dispatch(fetchAnswersSuccess(answers));
           dispatch(setLoading(false));
         },

--- a/src/screens/log/index.js
+++ b/src/screens/log/index.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, FlatList, Text, View } from 'react-native';
 import SafeAreaView from 'react-native-safe-area-view';
+import { RectButton } from 'react-native-gesture-handler';
+import Swipeable from 'react-native-gesture-handler/Swipeable';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -8,6 +10,7 @@ import { Ionicons } from '@expo/vector-icons';
 
 import moment from 'moment';
 import { colors } from '../../api/constants';
+import { deleteEntry } from '../../api/firestore';
 import Title from '../../components/common/Title';
 import { fetchAnswers } from '../../redux/actions/answer';
 import styles from './styles';
@@ -22,6 +25,10 @@ const Stats = () => {
   useEffect(() => {
     dispatch(fetchAnswers());
   }, []);
+
+  const onDeleteEntry = async (entry) => {
+    await deleteEntry(entry);
+  };
 
   return (
     <>
@@ -40,42 +47,59 @@ const Stats = () => {
                 alignItems: 'center',
               }}
             >
-              <View style={styles.logsContainer}>
-                {answers.map((item) => (
-                  <View
-                    key={item.createdAt}
-                    style={styles.itemContainer}
+              <FlatList
+                style={styles.logsContainer}
+                data={answers}
+                renderItem={({ item }) => (
+                  <Swipeable
+                    friction={2}
+                    rightThreshold={40}
+                    renderRightActions={() => (
+                      <RectButton
+                        style={styles.deleteAction}
+                        onPress={() => onDeleteEntry(item)}
+                      >
+                        <Ionicons
+                          name='trash-outline'
+                          color={colors.tertiary}
+                          size={24}
+                        />
+                      </RectButton>
+                    )}
                   >
-                    <View>
-                      {item.reason === 'Is not procrastinating' ? (
-                        <Ionicons
-                          name='checkmark-circle-outline'
-                          color={colors.success}
-                          size={20}
-                        />
-                      ) : (
-                        <Ionicons
-                          name='close-circle-outline'
-                          color={colors.danger}
-                          size={20}
-                        />
-                      )}
-                    </View>
-                    <View style={styles.textContainer}>
-                      <Text style={styles.reason}>
-                        {item.reason === 'Is not procrastinating'
-                          ? 'Not procrastinating'
-                          : item.reason}
-                      </Text>
-                      <Text>
-                        {moment(item.createdAt).format(
-                          'ddd D MMM, hh:mm A',
+                    <View style={styles.itemContainer}>
+                      <View>
+                        {item.reason === 'Is not procrastinating' ? (
+                          <Ionicons
+                            name='checkmark-circle-outline'
+                            color={colors.success}
+                            size={20}
+                          />
+                        ) : (
+                          <Ionicons
+                            name='close-circle-outline'
+                            color={colors.danger}
+                            size={20}
+                          />
                         )}
-                      </Text>
+                      </View>
+                      <View style={styles.textContainer}>
+                        <Text style={styles.reason}>
+                          {item.reason === 'Is not procrastinating'
+                            ? 'Not procrastinating'
+                            : item.reason}
+                        </Text>
+                        <Text>
+                          {moment(item.createdAt).format(
+                            'ddd D MMM, hh:mm A',
+                          )}
+                        </Text>
+                      </View>
                     </View>
-                  </View>
-                ))}
-              </View>
+                  </Swipeable>
+                )}
+                keyExtractor={item => item.createdAt}
+              />
             </ScrollView>
             {showPopup && (
               <Popup

--- a/src/screens/log/styles.js
+++ b/src/screens/log/styles.js
@@ -2,7 +2,10 @@ import { StyleSheet } from 'react-native';
 import { colors } from '../../api/constants';
 
 const styles = StyleSheet.create({
-  safeAreaView: { flex: 1, marginHorizontal: 15 },
+  safeAreaView: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
   skeleton: {
     width: '100%',
     height: 50,
@@ -13,15 +16,22 @@ const styles = StyleSheet.create({
     marginVertical: 12,
   },
   itemContainer: {
-    marginVertical: 8,
-    flex: 1,
+    paddingVertical: 8,
+    paddingHorizontal: 15,
     flexDirection: 'row',
     alignItems: 'center',
+    backgroundColor: colors.background,
   },
   textContainer: {
     marginLeft: 10,
   },
   reason: { fontSize: 18, color: colors.dark },
+  deleteAction: {
+    width: 80,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.danger,
+  },
 });
 
 export default styles;

--- a/src/screens/question/style.js
+++ b/src/screens/question/style.js
@@ -1,9 +1,11 @@
 import { StyleSheet } from 'react-native';
+import { colors } from '../../api/constants';
 
 const styles = StyleSheet.create({
   safeAreaQuestion: {
     flex: 1,
     marginHorizontal: 10,
+    backgroundColor: colors.background,
   },
   viewFourButtons: {
     flexDirection: 'row',

--- a/src/screens/settings/style.js
+++ b/src/screens/settings/style.js
@@ -4,6 +4,7 @@ import { colors } from '../../api/constants';
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
+    backgroundColor: colors.background,
   },
   scrollViewStyle: {
     marginTop: 20,

--- a/src/screens/stats/styles.js
+++ b/src/screens/stats/styles.js
@@ -5,6 +5,7 @@ const styles = StyleSheet.create({
   safeAreaView: {
     flex: 1,
     marginHorizontal: 15,
+    backgroundColor: colors.background,
   },
   chartContainer: {
     justifyContent: 'center',


### PR DESCRIPTION
This PR makes entries in the log tab swipeable from right to left, revealing a delete button.

As I recently downloaded the app and missclicked on a procrastination button, I found out the hard way that there was no way to cancel that action unless I created another account (losing all my stats, if I had some).

It adds a Firebase Analytics event called `entry_delete` with parameters `reason` and `date`.

It also requires that users have delete permissions on the Firestore collections `answers.{uid}.answers`, `answers.{uid}.history` and `answers.{uid}.counter`